### PR TITLE
resize docker image by using node:alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,7 @@
-FROM debian:stretch
-ENV DEBIAN_FRONTEND noninteractive
+FROM node:alpine
 
-# install curl ca-certificates gnupg apt-transport-https
-RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends curl ca-certificates gnupg apt-transport-https
-
-# Add nodesource for latest Node.js
-RUN echo "deb https://deb.nodesource.com/node_8.x stretch main" >> /etc/apt/sources.list.d/nodejs.list
-RUN curl --silent -o nodesource.gpg.key https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-RUN apt-key add nodesource.gpg.key
-RUN rm nodesource.gpg.key
-
-# install compiler, Node.js and dependencies
-RUN apt-get update -y
-RUN apt-get install -y --no-install-recommends git-core build-essential cmake
-RUN apt-get install -y --no-install-recommends nodejs libuv1-dev
+# install bash git cmake make gcc libc-dev libuv-dev
+RUN apk add --no-cache bash git cmake make gcc g++ libc-dev libuv-dev
 
 # Node.js package to keep the proxy running in case of failure
 RUN npm -g i forever


### PR DESCRIPTION
Gesagt, getan - https://pr0gramm.com/new/2052567:comment16505343
```
pro-miner-alpine     latest         6247e8bffebe        3 minutes ago       273MB
pro-miner            latest         b6b473d10b9a        11 hours ago        508MB
```
Fast 50% Platzersparnis durch Nutzung von Alpine statt Debian.